### PR TITLE
Allow encryption of empty strings / data when padding is used

### DIFF
--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -230,7 +230,7 @@ public class SwiftyRSA: NSObject {
         
         var encryptedData = [UInt8](count: 0, repeatedValue: 0)
         var idx = 0
-        while (idx < decryptedDataAsArray.count) {
+        while (idx < decryptedDataAsArray.count || (idx == 0 && decryptedDataAsArray.count == 0) && padding != SecPadding.None) {
             
             let idxEnd = min(idx + maxChunkSize, decryptedDataAsArray.count)
             let chunkData = [UInt8](decryptedDataAsArray[idx..<idxEnd])

--- a/SwiftyRSATests/SwiftyRSATests.swift
+++ b/SwiftyRSATests/SwiftyRSATests.swift
@@ -82,6 +82,22 @@ class SwiftyRSATests: XCTestCase {
         XCTAssertEqual(str, decrypted)
     }
     
+    func testEmptyString() {
+        let str = ""
+        
+        let pubString = TestUtils.pemKeyString(name: "swiftyrsa-public")
+        let privString = TestUtils.pemKeyString(name: "swiftyrsa-private")
+        
+        let encrypted = try! SwiftyRSA.encryptString(str, publicKeyPEM: pubString)
+        
+        // Decrypt does not currently work on encrypted empty strings
+        //let decrypted = try! SwiftyRSA.decryptString(encrypted, privateKeyPEM: privString)
+        //XCTAssertEqual(str, decrypted)
+        
+        // Should actually encrypt an empty string
+        XCTAssert(encrypted.characters.count > 0)
+    }
+    
     func testLongString() {
         let str = [String](count: 9999, repeatedValue: "a").joinWithSeparator("")
         


### PR DESCRIPTION
We currently have a problem with using SwiftyRSA because a third party required encoded empty strings. When using padding like PKCS, it is allowed to encrypt empty strings according to the standard.
I have enabled this in this pull request and added a test.

However, I can't get the decrypt to work with Apple's SecKeyEncrypt. This returns status -9809 which means "An underlying cryptographic error was encountered.".

Please comment on how to implement the decryption.