### PR TITLE
Add ability to create Public/PrivateKey with a SecKey, and export to PEM/base64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,10 @@ SwiftyRSA Changelog
 
 # [master]
 
- - `PublicKey` and `PrivateKey` now expose their keychain reference and the data they were created with.
+ - `PublicKey` and `PrivateKey` now expose their keychain reference and the data they were created with, in the `reference` and `originalData` fields.
    [#60](https://github.com/TakeScoop/SwiftyRSA/issues/60)
-   - `PublicKey` now exposes the following fields:
-     - `reference`: reference to the key in the keychain
-     - `data`: data with which the key was created
-     - `dataWithoutHeader`: data with the x509 header
-   - `PrivateKey` now exposes the following fields:
-     - `reference`: reference to the key in the keychain
-     - `data`: data with which the key was created
+ - `PublicKey` and `PrivateKey` now have a method `data()` which returns the key data as exported by the keychain.
+	[#60](https://github.com/TakeScoop/SwiftyRSA/issues/60)
  - Fixed a bug that would pass a wrong bit size to `SecKeyCreateWithData` on iOS 10+.
    [https://github.com/TakeScoop/SwiftyRSA/issues/58](#58)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ SwiftyRSA Changelog
    [#60](https://github.com/TakeScoop/SwiftyRSA/issues/60)
  - `PublicKey` and `PrivateKey` now have a method `data()` which returns the key data as exported by the keychain.
 	[#60](https://github.com/TakeScoop/SwiftyRSA/issues/60)
+ - `PublicKey` and `PrivateKey` now can be exported to PEM via the `pemString()` method, or base64 via the `base64String()` method.
+   [#60](https://github.com/TakeScoop/SwiftyRSA/issues/60)
+ - `PublicKey` and `PrivateKey` now can be created from a `SecKey` reference.
+   [#48](https://github.com/TakeScoop/SwiftyRSA/issues/48)
  - Fixed a bug that would pass a wrong bit size to `SecKeyCreateWithData` on iOS 10+.
    [https://github.com/TakeScoop/SwiftyRSA/issues/58](#58)
 

--- a/SwiftyRSA.xcodeproj/project.pbxproj
+++ b/SwiftyRSA.xcodeproj/project.pbxproj
@@ -653,7 +653,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = SwiftyRSATests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.takescoop.SwiftyRSATests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -670,7 +670,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				INFOPLIST_FILE = SwiftyRSATests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.takescoop.SwiftyRSATests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/SwiftyRSA/Key.swift
+++ b/SwiftyRSA/Key.swift
@@ -47,6 +47,14 @@ public protocol Key {
         return pem
     }
     
+    /// Returns a Base64 representation of the public key.
+    ///
+    /// - Returns: Data of the key, Base64-encoded
+    /// - Throws: SwiftyRSAError
+    @objc public func base64String() throws -> String {
+        return try data().base64EncodedString()
+    }
+    
     /// Creates a public key with a keychain key reference.
     /// This initializer will throw if the provided key reference is not a public RSA key.
     ///
@@ -197,6 +205,14 @@ public protocol Key {
     /// - Throws: SwiftyRSAError
     @objc public func data() throws -> Data {
         return try SwiftyRSA.data(forKeyReference: reference)
+    }
+    
+    /// Returns a Base64 representation of the private key.
+    ///
+    /// - Returns: Data of the key, Base64-encoded
+    /// - Throws: SwiftyRSAError
+    @objc public func base64String() throws -> String {
+        return try data().base64EncodedString()
     }
     
     /// Returns a PEM representation of the private key.

--- a/SwiftyRSA/Key.swift
+++ b/SwiftyRSA/Key.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Security
 
 typealias PEMString = String
 
@@ -19,16 +20,22 @@ public protocol Key {
     /// Reference to the key within the keychain
     public let reference: SecKey
     
-    /// Tag of the key within the keychain
-    public let tag: String?
-    
-    /// Data of the public key without a x509 header.
-    /// Since SwiftyRSA strips public key headers, `key.data` might be different then `key.dataWithoutHeader`.
-    public let dataWithoutHeader: Data?
-    
     /// Data of the public key as provided when creating the key.
-    /// Note that it does not contain PEM headers and holds data as bytes, not as a base 64 string.
-    public let data: Data?
+    /// Note that if the key was created from a base64string / DER string / PEM file / DER file,
+    /// the data holds the actual bytes of the key, not any textual representation like PEM headers
+    /// or base64 characters.
+    public let originalData: Data?
+    
+    let tag: String? // Only used on iOS 8/9
+    
+    /// Data of the public key as returned by the keychain.
+    /// This method throws if SwiftyRSA cannot extract data from the key.
+    ///
+    /// - Returns: Data of the public key as returned by the keychain.
+    /// - Throws: SwiftyRSAError
+    @objc public func data() throws -> Data {
+        return try SwiftyRSA.data(forKeyReference: reference)
+    }
     
     /// Creates a public key with a keychain key reference.
     /// This initializer will throw if the provided key reference is not a public RSA key.
@@ -43,8 +50,7 @@ public protocol Key {
         
         self.reference = reference
         self.tag = nil
-        self.data = nil
-        self.dataWithoutHeader = nil
+        self.originalData = nil
     }
     
     /// Creates a public key with a RSA public key data.
@@ -56,9 +62,8 @@ public protocol Key {
         let tag = UUID().uuidString
         self.tag = tag
         
+        self.originalData = data
         let dataWithoutHeader = try SwiftyRSA.stripPublicKeyHeader(keyData: data)
-        self.dataWithoutHeader = dataWithoutHeader
-        self.data = data
         
     	reference = try SwiftyRSA.addKey(dataWithoutHeader, isPublic: true, tag: tag)
     }
@@ -169,12 +174,20 @@ public protocol Key {
     /// Reference to the key within the keychain
     public let reference: SecKey
     
-    /// Tag of the key within the keychain
-    public let tag: String?
-    
     /// Original data of the private key.
     /// Note that it does not contain PEM headers and holds data as bytes, not as a base 64 string.
-    public let data: Data?
+    public let originalData: Data?
+    
+    let tag: String?
+    
+    /// Data of the private key as returned by the keychain.
+    /// This method throws if SwiftyRSA cannot extract data from the key.
+    ///
+    /// - Returns: Data of the public key as returned by the keychain.
+    /// - Throws: SwiftyRSAError
+    @objc public func data() throws -> Data {
+        return try SwiftyRSA.data(forKeyReference: reference)
+    }
     
     /// Creates a private key with a keychain key reference.
     /// This initializer will throw if the provided key reference is not a private RSA key.
@@ -189,7 +202,7 @@ public protocol Key {
         
         self.reference = reference
         self.tag = nil
-        self.data = nil
+        self.originalData = nil
     }
     
     /// Creates a private key with a RSA public key data.
@@ -197,7 +210,7 @@ public protocol Key {
     /// - Parameter data: Private key data
     /// - Throws: SwiftyRSAError
     required public init(data: Data) throws {
-        self.data = data
+        self.originalData = data
         let tag = UUID().uuidString
         self.tag = tag
         reference = try SwiftyRSA.addKey(data, isPublic: false, tag: tag)

--- a/SwiftyRSA/Key.swift
+++ b/SwiftyRSA/Key.swift
@@ -37,6 +37,16 @@ public protocol Key {
         return try SwiftyRSA.data(forKeyReference: reference)
     }
     
+    /// Returns a PEM representation of the public key.
+    ///
+    /// - Returns: Data of the key, PEM-encoded
+    /// - Throws: SwiftyRSAError
+    @objc public func pemString() throws -> String {
+        let data = try self.data()
+        let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PUBLIC KEY")
+        return pem
+    }
+    
     /// Creates a public key with a keychain key reference.
     /// This initializer will throw if the provided key reference is not a public RSA key.
     ///
@@ -187,6 +197,16 @@ public protocol Key {
     /// - Throws: SwiftyRSAError
     @objc public func data() throws -> Data {
         return try SwiftyRSA.data(forKeyReference: reference)
+    }
+    
+    /// Returns a PEM representation of the private key.
+    ///
+    /// - Returns: Data of the key, PEM-encoded
+    /// - Throws: SwiftyRSAError
+    @objc public func pemString() throws -> String {
+        let data = try self.data()
+        let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PRIVATE KEY")
+        return pem
     }
     
     /// Creates a private key with a keychain key reference.

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -59,6 +59,27 @@ enum SwiftyRSA {
         return isRSA && isValidClass
     }
     
+    static func format(keyData: Data, withPemType pemType: String) -> String {
+        
+        func split(_ str: String, byChunksOfLength length: Int) -> [String] {
+            return stride(from: 0, to: str.characters.count, by: length).map { i -> String in
+                let startIndex = str.index(str.startIndex, offsetBy: i)
+                let endIndex   = str.index(startIndex, offsetBy: length, limitedBy: str.endIndex) ?? str.endIndex
+                return str[startIndex..<endIndex]
+            }
+        }
+        
+        let chunks = split(keyData.base64EncodedString(), byChunksOfLength: 64)
+        
+        let pem = [
+            "-----BEGIN \(pemType)-----",
+            chunks.joined(separator: "\n"),
+            "-----END \(pemType)-----"
+        ]
+        
+        return pem.joined(separator: "\n")
+    }
+    
     static func data(forKeyReference reference: SecKey) throws -> Data {
         
         // On iOS+, we can use `SecKeyCopyExternalRepresentation` directly

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -62,9 +62,9 @@ enum SwiftyRSA {
     static func format(keyData: Data, withPemType pemType: String) -> String {
         
         func split(_ str: String, byChunksOfLength length: Int) -> [String] {
-            return stride(from: 0, to: str.characters.count, by: length).map { i -> String in
-                let startIndex = str.index(str.startIndex, offsetBy: i)
-                let endIndex   = str.index(startIndex, offsetBy: length, limitedBy: str.endIndex) ?? str.endIndex
+            return stride(from: 0, to: str.characters.count, by: length).map { index -> String in
+                let startIndex = str.index(str.startIndex, offsetBy: index)
+                let endIndex = str.index(startIndex, offsetBy: length, limitedBy: str.endIndex) ?? str.endIndex
                 return str[startIndex..<endIndex]
             }
         }

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -13,6 +13,10 @@ public typealias Padding = SecPadding
 
 struct SwiftyRSAError: Error {
     let message: String
+    
+    init(message: String) {
+        self.message = message
+    }
 }
 
 extension CFString: Hashable {
@@ -37,6 +41,22 @@ enum SwiftyRSA {
         }
         
         return lines.joined(separator: "")
+    }
+    
+    static func isValidKeyReference(_ reference: SecKey, forClass requiredClass: CFString) -> Bool {
+        
+        guard #available(iOS 10.0, *) else {
+            return true
+        }
+        
+        let attributes = SecKeyCopyAttributes(reference) as? [CFString: Any]
+        guard let keyType = attributes?[kSecAttrKeyType] as? String, let keyClass = attributes?[kSecAttrKeyClass] as? String else {
+            return false
+        }
+        
+        let isRSA = keyType == kSecAttrKeyTypeRSA as String
+        let isValidClass = keyClass == requiredClass as String
+        return isRSA && isValidClass
     }
     
     static func addKey(_ keyData: Data, isPublic: Bool, tag: String) throws ->  SecKey {

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -54,8 +54,8 @@ enum SwiftyRSA {
             return false
         }
         
-        let isRSA = keyType == kSecAttrKeyTypeRSA as String
-        let isValidClass = keyClass == requiredClass as String
+        let isRSA = keyType == (kSecAttrKeyTypeRSA as String)
+        let isValidClass = keyClass == (requiredClass as String)
         return isRSA && isValidClass
     }
     

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -45,7 +45,7 @@ enum SwiftyRSA {
     
     static func isValidKeyReference(_ reference: SecKey, forClass requiredClass: CFString) -> Bool {
         
-        guard #available(iOS 10.0, *) else {
+        guard #available(iOS 10.0, *), #available(watchOS 3.0, *), #available(tvOS 10.0, *) else {
             return true
         }
         
@@ -83,7 +83,7 @@ enum SwiftyRSA {
     static func data(forKeyReference reference: SecKey) throws -> Data {
         
         // On iOS+, we can use `SecKeyCopyExternalRepresentation` directly
-        if #available(iOS 10.0, *) {
+        if #available(iOS 10.0, *), #available(watchOS 3.0, *), #available(tvOS 10.0, *) {
             
             let data = SecKeyCopyExternalRepresentation(reference, nil)
             guard let unwrappedData = data as? Data else {

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -69,6 +69,9 @@ enum SwiftyRSA {
             }
         }
         
+        // Line length is typically 64 characters, except the last line.
+        // See https://tools.ietf.org/html/rfc7468#page-6 (64base64char)
+        // See https://tools.ietf.org/html/rfc7468#page-11 (example)
         let chunks = split(keyData.base64EncodedString(), byChunksOfLength: 64)
         
         let pem = [

--- a/SwiftyRSATests/EncryptDecryptTests.swift
+++ b/SwiftyRSATests/EncryptDecryptTests.swift
@@ -59,4 +59,77 @@ class EncryptDecryptTests: XCTestCase {
         
         XCTAssertEqual(decrypted.data, data)
     }
+    
+    func test_keyReferences() throws {
+        let data = TestUtils.randomData(count: 2048)
+        let clearMessage = ClearMessage(data: data)
+        
+        let newPublicKey = try PublicKey(reference: publicKey.reference)
+        let newPrivateKey = try PrivateKey(reference: privateKey.reference)
+        
+        // Encrypt with old public key, decrypt with old private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: publicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: privateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with old public key, decrypt with new private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: publicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: newPrivateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with new public key, decrypt with old private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: newPublicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: privateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with new public key, decrypt with new private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: newPublicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: newPrivateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+    }
+    
+    func test_keyData() throws {
+        
+        let data = TestUtils.randomData(count: 2048)
+        let clearMessage = ClearMessage(data: data)
+        
+        let newPublicKey = try PublicKey(data: try publicKey.data())
+        let newPrivateKey = try PrivateKey(data: try privateKey.data())
+        
+        // Encrypt with old public key, decrypt with old private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: publicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: privateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with old public key, decrypt with new private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: publicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: newPrivateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with new public key, decrypt with old private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: newPublicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: privateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+        
+        // Encrypt with new public key, decrypt with new private key
+        do {
+            let encrypted = try clearMessage.encrypted(with: newPublicKey, padding: .PKCS1)
+            let decrypted = try encrypted.decrypted(with: newPrivateKey, padding: .PKCS1)
+            XCTAssertEqual(decrypted.data, data)
+        }
+    }
 }

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -112,7 +112,7 @@ class PublicKeyTests: XCTestCase {
         XCTAssertEqual(keys.count, 0)
     }
     
-    func test_dataProperty() throws {
+    func test_data() throws {
         
         // With header
         do {
@@ -121,8 +121,13 @@ class PublicKeyTests: XCTestCase {
             }
             let data = try Data(contentsOf: URL(fileURLWithPath: path))
             let publicKey = try PublicKey(data: data)
-            XCTAssertEqual(publicKey.data, data)
-            XCTAssertNotEqual(publicKey.dataWithoutHeader, data)
+            
+            guard let dataFromKeychain = try? publicKey.data() else {
+                return XCTFail()
+            }
+            
+            XCTAssertNotEqual(dataFromKeychain, data)
+            XCTAssertEqual(publicKey.originalData, data)
         }
         
         // Headerless
@@ -132,7 +137,8 @@ class PublicKeyTests: XCTestCase {
             }
             let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
             let publicKey = try PublicKey(pemEncoded: str)
-            XCTAssertEqual(publicKey.dataWithoutHeader, publicKey.data)
+            XCTAssertNotNil(publicKey.originalData)
+            XCTAssertNotNil(try? publicKey.data())
         }
     }
 }
@@ -202,6 +208,6 @@ class PrivateKeyTests: XCTestCase {
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         let publicKey = try PrivateKey(data: data)
-        XCTAssertEqual(publicKey.data, data)
+        XCTAssertEqual(try? publicKey.data(), data)
     }
 }

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -13,6 +13,33 @@ class PublicKeyTests: XCTestCase {
     
     let bundle = Bundle(for: PublicKeyTests.self)
     
+    func test_initWithReference() throws {
+        guard let path = bundle.path(forResource: "swiftyrsa-public", ofType: "der") else {
+            return XCTFail()
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let publicKey = try PublicKey(data: data)
+
+        let newPublicKey = try? PublicKey(reference: publicKey.reference)
+        XCTAssertNotNil(newPublicKey)
+    }
+    
+    func test_initWithReference_failsWithPrivateKey() throws {
+        
+        // We can't do key reference checking on iOS 8/9
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+        
+        guard let path = bundle.path(forResource: "swiftyrsa-private", ofType: "pem") else {
+            return XCTFail()
+        }
+        let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+        let privateKey = try PrivateKey(pemEncoded: str)
+        
+        XCTAssertThrowsError(try PublicKey(reference: privateKey.reference))
+    }
+    
     func test_initWithData() throws {
         guard let path = bundle.path(forResource: "swiftyrsa-public", ofType: "der") else {
             return XCTFail()
@@ -113,6 +140,33 @@ class PublicKeyTests: XCTestCase {
 class PrivateKeyTests: XCTestCase {
     
     let bundle = Bundle(for: PublicKeyTests.self)
+    
+    func test_initWithReference() throws {
+        guard let path = bundle.path(forResource: "swiftyrsa-private", ofType: "pem") else {
+            return XCTFail()
+        }
+        let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+        let privateKey = try PrivateKey(pemEncoded: str)
+        
+        let newPrivateKey = try? PrivateKey(reference: privateKey.reference)
+        XCTAssertNotNil(newPrivateKey)
+    }
+    
+    func test_initWithReference_failsWithPublicKey() throws {
+        
+        // We can't do key reference checking on iOS 8/9
+        guard #available(iOS 10.0, *) else {
+            return
+        }
+        
+        guard let path = bundle.path(forResource: "swiftyrsa-public", ofType: "der") else {
+            return XCTFail()
+        }
+        let data = try Data(contentsOf: URL(fileURLWithPath: path))
+        let publicKey = try PublicKey(data: data)
+        
+        XCTAssertThrowsError(try PrivateKey(reference: publicKey.reference))
+    }
     
     func test_initWithPEMString() throws {
         guard let path = bundle.path(forResource: "swiftyrsa-private", ofType: "pem") else {

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -77,13 +77,13 @@ class PublicKeyTests: XCTestCase {
     }
     
     func test_initWithPEMName() throws {
-        let message = try? PublicKey(pemNamed: "swiftyrsa-public", in: Bundle(for: TestUtils.self))
-        XCTAssertNotNil(message)
+        let publicKey = try? PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        XCTAssertNotNil(publicKey)
     }
     
     func test_initWithDERName() throws {
-        let message = try? PublicKey(pemNamed: "swiftyrsa-public", in: Bundle(for: TestUtils.self))
-        XCTAssertNotNil(message)
+        let publicKey = try? PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        XCTAssertNotNil(publicKey)
     }
     
     func test_initWithPEMStringHeaderless() throws {
@@ -140,6 +140,13 @@ class PublicKeyTests: XCTestCase {
             XCTAssertNotNil(publicKey.originalData)
             XCTAssertNotNil(try? publicKey.data())
         }
+    }
+    
+    func test_pemString() throws {
+        let publicKey = try PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let pemString = try publicKey.pemString()
+        let newPublicKey = try PublicKey(pemEncoded: pemString)
+        XCTAssertNotNil(newPublicKey)
     }
 }
 
@@ -202,12 +209,19 @@ class PrivateKeyTests: XCTestCase {
         XCTAssertNotNil(message)
     }
     
-    func test_dataProperty() throws {
+    func test_data() throws {
         guard let path = bundle.path(forResource: "swiftyrsa-private", ofType: "der") else {
             return XCTFail()
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         let publicKey = try PrivateKey(data: data)
         XCTAssertEqual(try? publicKey.data(), data)
+    }
+    
+    func test_pemString() throws {
+        let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
+        let pemString = try privateKey.pemString()
+        let newPrivateKey = try PrivateKey(pemEncoded: pemString)
+        XCTAssertNotNil(newPrivateKey)
     }
 }

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -147,6 +147,7 @@ class PublicKeyTests: XCTestCase {
         let pemString = try publicKey.pemString()
         let newPublicKey = try PublicKey(pemEncoded: pemString)
         XCTAssertNotNil(newPublicKey)
+        XCTAssertEqual(try? publicKey.data(), try? newPublicKey.data())
     }
     
     func test_base64String() throws {
@@ -154,6 +155,7 @@ class PublicKeyTests: XCTestCase {
         let base64String = try publicKey.base64String()
         let newPublicKey = try PublicKey(base64Encoded: base64String)
         XCTAssertNotNil(newPublicKey)
+        XCTAssertEqual(try? publicKey.data(), try? newPublicKey.data())
     }
 }
 
@@ -230,12 +232,13 @@ class PrivateKeyTests: XCTestCase {
         let pemString = try privateKey.pemString()
         let newPrivateKey = try PrivateKey(pemEncoded: pemString)
         XCTAssertNotNil(newPrivateKey)
+        XCTAssertEqual(try? privateKey.data(), try? newPrivateKey.data())
     }
     
     func test_base64String() throws {
         let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
         let base64String = try privateKey.base64String()
         let newPrivateKey = try PrivateKey(base64Encoded: base64String)
-        XCTAssertNotNil(newPrivateKey)
+        XCTAssertEqual(try? privateKey.data(), try? newPrivateKey.data())
     }
 }

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -148,6 +148,13 @@ class PublicKeyTests: XCTestCase {
         let newPublicKey = try PublicKey(pemEncoded: pemString)
         XCTAssertNotNil(newPublicKey)
     }
+    
+    func test_base64String() throws {
+        let publicKey = try PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let base64String = try publicKey.base64String()
+        let newPublicKey = try PublicKey(base64Encoded: base64String)
+        XCTAssertNotNil(newPublicKey)
+    }
 }
 
 class PrivateKeyTests: XCTestCase {
@@ -222,6 +229,13 @@ class PrivateKeyTests: XCTestCase {
         let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
         let pemString = try privateKey.pemString()
         let newPrivateKey = try PrivateKey(pemEncoded: pemString)
+        XCTAssertNotNil(newPrivateKey)
+    }
+    
+    func test_base64String() throws {
+        let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
+        let base64String = try privateKey.base64String()
+        let newPrivateKey = try PrivateKey(base64Encoded: base64String)
         XCTAssertNotNil(newPrivateKey)
     }
 }

--- a/SwiftyRSATests/ObjCTests.m
+++ b/SwiftyRSATests/ObjCTests.m
@@ -30,8 +30,9 @@
     pub = [[PublicKey alloc] initWithBase64Encoded:@"test" error:nil];
     pub = [[PublicKey alloc] initWithPemNamed:@"test" in: [NSBundle bundleForClass:[TestUtils class]] error:nil];
     pub = [[PublicKey alloc] initWithDerNamed:@"test" in: [NSBundle bundleForClass:[TestUtils class]] error:nil];
-    [pub data];
-    [pub dataWithoutHeader];
+    
+    [pub dataAndReturnError:nil];
+    [pub originalData];
     [PublicKey publicKeysWithPemEncoded:@"test"];
     
     PrivateKey* priv;
@@ -40,7 +41,8 @@
     priv = [[PrivateKey alloc] initWithPemNamed:@"test" in: [NSBundle bundleForClass:[TestUtils class]] error:nil];
     priv = [[PrivateKey alloc] initWithDerNamed:@"test" in: [NSBundle bundleForClass:[TestUtils class]] error:nil];
     priv = [[PrivateKey alloc] initWithBase64Encoded:@"test" error:nil];
-    [priv data];
+    [priv dataAndReturnError:nil];
+    [priv originalData];
     
     Signature* signature;
     signature = [[Signature alloc] initWithBase64Encoded:@"test" error:nil];


### PR DESCRIPTION
@paulw11 @greenantdotcom @quentinlesceller Please review

Fixes #48 and #60

Added the following methods to `PublicKey` and `PrivateKey`:
 - `init(reference:)` to create a key from a `SecKey` reference
 - `data()` to gather a key raw data from the keychain
 - `pemString()` to export a key to its PEM representation
 - `base64String()` to export a key to its base64 representation

I'm not a huge fan of having so many `throws`, it really forces to have swiftyrsa usage all within a `do/catch`. However we do need to handle all the weird errors that the keychain can return, or even user errors (providing a private key reference to create a public key). Ideally I'd like to have `throws` only at the initializer phase, and then no `throws` for all methods, but I don't see a way of doing this right now.

Let me know if you have any comment / questions.