### PR TITLE
Fixed Swiftlint Usage

### DIFF
--- a/SwiftyRSA.xcodeproj/project.pbxproj
+++ b/SwiftyRSA.xcodeproj/project.pbxproj
@@ -464,7 +464,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/SwiftLint/swiftlint\"";
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint autocorrect\n    swiftlint\nelse\n    echo \"warning: SwiftLint not installed. Install using brew update && brew install swiftlint or download from https://github.com/realm/SwiftLint.\"\nfi";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
The change to add SwiftLint breaks Carthage builds, since it introduced a dependency (SwiftLint via CocoaPods) that isn't resolved and included in the Carthage build.

There should probably be some kind of Example project for development where you'd run SwiftLint, but since there isn't one I added a quick fix to check for a local version of SwiftLint and warn the user, rather than breaking the build.