### PR TITLE
Fix key initialization typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ Advanced Usage
 
 ```swift
 let publicKey = try PublicKey(derNamed: "public")
-let privateKey = try PublicKey(derNamed: "private")
+let privateKey = try PrivateKey(derNamed: "private")
 ```
 
 #### With a PEM file
 
 ```swift
 let publicKey = try PublicKey(pemNamed: "public")
-let privateKey = try PublicKey(pemNamed: "private")
+let privateKey = try PrivateKey(pemNamed: "private")
 ```
 
 #### With a PEM string


### PR DESCRIPTION
There were two small typos where the `PublicKey` initializer was used to initialize a private key in the code examples in the readme. This PR fixes these typos. 🤓 