### PR TITLE
Changes rangeAt(:) into rangeAt(at:)

### DIFF
--- a/SwiftyRSA/PublicKey.swift
+++ b/SwiftyRSA/PublicKey.swift
@@ -95,7 +95,7 @@ public class PublicKey: Key {
         )
         
         let keys = matches.flatMap { result -> PublicKey? in
-            let match = result.rangeAt(1)
+            let match = result.range(at: 1)
             let start = pemString.characters.index(pemString.startIndex, offsetBy: match.location)
             let end = pemString.characters.index(start, offsetBy: match.length)
             


### PR DESCRIPTION
This commit fixes an error for a Swift 4 deprecation 