### PR TITLE
Added ‘generateRSAKeyPair’ to SwiftyRSA enum.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SwiftyRSA Changelog
 
  - Fixed compilation warnings for Xcode 9.1 / 9.2.
 
+# [1.4.0]
+
+- Added `generateRSAKeyPair` to SwiftyRSA enum. [#106](https://github.com/TakeScoop/SwiftyRSA/issues/106)
+
 # [1.3.0]
 
  - Added Swift 3.2 and 4.0 support.
@@ -105,6 +109,7 @@ We recommend to check out the new [usage instructions](./README.md) to migrate c
 Initial release.
 
 [master]: https://github.com/TakeScoop/SwiftyRSA/tree/master
+[1.4.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.4.0
 [1.3.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.3.0
 [1.2.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.2.0
 [1.1.1]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,7 @@ SwiftyRSA Changelog
 
  - Fixed compilation warnings for Xcode 9.1 / 9.2.
 
-# [1.4.0]
-
-- Added `generateRSAKeyPair` to SwiftyRSA enum. [#106](https://github.com/TakeScoop/SwiftyRSA/issues/106)
+ - Added `generateRSAKeyPair` to SwiftyRSA enum. [#106](https://github.com/TakeScoop/SwiftyRSA/issues/106)
 
 # [1.3.0]
 

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ let publicKey = try PublicKey(reference: secKey)
 let privateKey = try PrivateKey(reference: secKey)
 ```
 
+### Create a public/private RSA key pair
+```swift
+let tag = "\(BUNDLE_IDENTIFIER).PrivateKey"
+let keyPair = SwiftRSA.generateRSAKeyPair(tag: tag, sizeInBits: 2048, storeInKeyChain: true)
+let privateKey = keyPair.privateKey
+let publicKey = keyPair.publicKey
+```
+
 ### Encrypt with a public key
 
 ```swift

--- a/SwiftyRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwiftyRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SwiftyRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwiftyRSA.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA iOS.xcscheme
+++ b/SwiftyRSA.xcodeproj/xcshareddata/xcschemes/SwiftyRSA iOS.xcscheme
@@ -40,8 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -52,6 +52,11 @@
                BlueprintName = "SwiftyRSATests"
                ReferencedContainer = "container:SwiftyRSA.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "PrivateKeyTests/test_generateKeyPair()">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -122,7 +122,7 @@ public enum SwiftyRSA {
         }
     }
     
-    /// Wlll generate a new private and public key
+    /// Will generate a new private and public key
     ///
     /// - Parameters:
     ///   - size: Indicates the total number of bits in this cryptographic key
@@ -142,10 +142,9 @@ public enum SwiftyRSA {
         let attributes: [CFString: Any] = [
             kSecAttrKeyType: kSecAttrKeyTypeRSA,
             kSecAttrKeySizeInBits: size,
-            kSecPrivateKeyAttrs:
-                [
-                    kSecAttrIsPermanent: true,
-                    kSecAttrApplicationTag: tagData
+            kSecPrivateKeyAttrs: [
+                kSecAttrIsPermanent: true,
+                kSecAttrApplicationTag: tagData
             ]
         ]
         var error: Unmanaged<CFError>?
@@ -186,7 +185,7 @@ public enum SwiftyRSA {
             }
             return key
             
-            // On iOS 9 and earlier, add a persistent version of the key to the system keychain
+        // On iOS 9 and earlier, add a persistent version of the key to the system keychain
         } else {
             
             let persistKey = UnsafeMutablePointer<AnyObject?>(mutating: nil)
@@ -213,7 +212,7 @@ public enum SwiftyRSA {
                 kSecAttrKeyClass: keyClass,
                 kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
                 kSecReturnRef: true,
-                ]
+            ]
             
             // Now fetch the SecKeyRef version of the key
             var keyRef: AnyObject? = nil
@@ -274,7 +273,7 @@ public enum SwiftyRSA {
                 return false
             }
             return true
-            }.isEmpty
+        }.isEmpty
         
         // Headerless key
         if onlyHasIntegers {
@@ -305,7 +304,7 @@ public enum SwiftyRSA {
             kSecClass: kSecClassKey,
             kSecAttrKeyType: kSecAttrKeyTypeRSA,
             kSecAttrApplicationTag: tagData,
-            ]
+          ]
         
         SecItemDelete(keyRemoveDict as CFDictionary)
     }

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -125,25 +125,27 @@ public enum SwiftyRSA {
     /// Wlll generate a new private and public key
     ///
     /// - Parameters:
-    ///   - tag: A string representing a 'tag' in the keychaing. Usually your bundle identifier
-    ///   - size: Indicates the total number of bits in this cryptographic key.
-    ///   - permanent: Whether to store it in the keychain or not
+    ///   - size: Indicates the total number of bits in this cryptographic key
     /// - Returns: A touple of a private and public key
     /// - Throws: Throws and error if the tag cant be parsed or if keygeneration fails
     @available(iOS 10.0, *)
-    public static func generateRSAKeyPair(tag: String, sizeInBits size: Int, storeInKeyChain permanent: Bool) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
-        
+    public static func generateRSAKeyPair(sizeInBits size: Int) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
+      
+        guard let tag = Bundle.main.bundleIdentifier else {
+            throw SwiftyRSAError.tagEncodingFailed
+        }
+      
         guard let tagData = tag.data(using: .utf8) else {
             throw SwiftyRSAError.stringToDataConversionFailed
         }
         
-        let attributes: [String: Any] = [
-            kSecAttrKeyType as String: kSecAttrKeyTypeRSA,
-            kSecAttrKeySizeInBits as String: size,
-            kSecPrivateKeyAttrs as String:
+        let attributes: [CFString: Any] = [
+            kSecAttrKeyType: kSecAttrKeyTypeRSA,
+            kSecAttrKeySizeInBits: size,
+            kSecPrivateKeyAttrs:
                 [
-                    kSecAttrIsPermanent as String: permanent,
-                    kSecAttrApplicationTag as String: tagData
+                    kSecAttrIsPermanent: true,
+                    kSecAttrApplicationTag: tagData
             ]
         ]
         var error: Unmanaged<CFError>?

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -27,7 +27,7 @@ extension Data {
     }
 }
 
-enum SwiftyRSA {
+public enum SwiftyRSA {
     
     static func base64String(pemEncoded pemString: String) throws -> String {
         let lines = pemString.components(separatedBy: "\n").filter { line in
@@ -122,8 +122,6 @@ enum SwiftyRSA {
         }
     }
     
-    
-    @available(iOS 10.0, *)
     /// Wlll generate a new private and public key
     ///
     /// - Parameters:
@@ -132,7 +130,8 @@ enum SwiftyRSA {
     ///   - permanent: Whether to store it in the keychain or not
     /// - Returns: A touple of a private and public key
     /// - Throws: Throws and error if the tag cant be parsed or if keygeneration fails
-    static func generateRSAKeyPair(tag: String, sizeInBits size: Int, storeInKeyChain permanent: Bool) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
+    @available(iOS 10.0, *)
+    public static func generateRSAKeyPair(tag: String, sizeInBits size: Int, storeInKeyChain permanent: Bool) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
         
         guard let tagData = tag.data(using: .utf8) else {
             throw SwiftyRSAError.stringToDataConversionFailed

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -122,7 +122,16 @@ enum SwiftyRSA {
         }
     }
     
+    
     @available(iOS 10.0, *)
+    /// Wlll generate a new private and public key
+    ///
+    /// - Parameters:
+    ///   - tag: A string representing a 'tag' in the keychaing. Usually your bundle identifier
+    ///   - size: Indicates the total number of bits in this cryptographic key.
+    ///   - permanent: Whether to store it in the keychain or not
+    /// - Returns: A touple of a private and public key
+    /// - Throws: Throws and error if the tag cant be parsed or if keygeneration fails
     static func generateRSAKeyPair(tag: String, sizeInBits size: Int, storeInKeyChain permanent: Bool) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
         
         guard let tagData = tag.data(using: .utf8) else {
@@ -225,18 +234,18 @@ enum SwiftyRSA {
      
      Headerless:
      SEQUENCE
-     INTEGER (1024 or 2048 bit) -- modulo
-     INTEGER -- public exponent
+         INTEGER (1024 or 2048 bit) -- modulo
+         INTEGER -- public exponent
      
      With x509 header:
      SEQUENCE
-     SEQUENCE
-     OBJECT IDENTIFIER 1.2.840.113549.1.1.1
-     NULL
-     BIT STRING
-     SEQUENCE
-     INTEGER (1024 or 2048 bit) -- modulo
-     INTEGER -- public exponent
+         SEQUENCE
+         OBJECT IDENTIFIER 1.2.840.113549.1.1.1
+         NULL
+         BIT STRING
+         SEQUENCE
+         INTEGER (1024 or 2048 bit) -- modulo
+         INTEGER -- public exponent
      
      Example of headerless key:
      https://lapo.it/asn1js/#3082010A0282010100C1A0DFA367FBC2A5FD6ED5A071E02A4B0617E19C6B5AD11BB61192E78D212F10A7620084A3CED660894134D4E475BAD7786FA1D40878683FD1B7A1AD9C0542B7A666457A270159DAC40CE25B2EAE7CCD807D31AE725CA394F90FBB5C5BA500545B99C545A9FE08EFF00A5F23457633E1DB84ED5E908EF748A90F8DFCCAFF319CB0334705EA012AF15AA090D17A9330159C9AFC9275C610BB9B7C61317876DC7386C723885C100F774C19830F475AD1E9A9925F9CA9A69CE0181A214DF2EB75FD13E6A546B8C8ED699E33A8521242B7E42711066AEC22D25DD45D56F94D3170D6F2C25164D2DACED31C73963BA885ADCB706F40866B8266433ED5161DC50E4B3B0203010001

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -93,8 +93,8 @@ public enum SwiftyRSA {
             }
             return unwrappedData
             
-            // On iOS 8/9, we need to add the key again to the keychain with a temporary tag, grab the data,
-            // and delete the key again.
+        // On iOS 8/9, we need to add the key again to the keychain with a temporary tag, grab the data,
+        // and delete the key again.
         } else {
             
             let temporaryTag = UUID().uuidString

--- a/SwiftyRSA/SwiftyRSAError.swift
+++ b/SwiftyRSA/SwiftyRSAError.swift
@@ -12,6 +12,7 @@ public enum SwiftyRSAError: Error {
     
     case pemDoesNotContainKey
     case keyRepresentationFailed(error: CFError?)
+    case keyGenerationFailed(error: CFError?)
     case keyCreateFailed(error: CFError?)
     case keyAddFailed(status: OSStatus)
     case keyCopyFailed(status: OSStatus)
@@ -38,6 +39,8 @@ public enum SwiftyRSAError: Error {
             return "Couldn't get data from PEM key: no data available after stripping headers"
         case .keyRepresentationFailed(let error):
             return "Couldn't retrieve key data from the keychain: CFError \(String(describing: error))"
+        case .keyGenerationFailed(let error):
+            return "Couldn't generate key pair: CFError: \(String(describing: error))"
         case .keyCreateFailed(let error):
             return "Couldn't create key reference from key data: CFError \(String(describing: error))"
         case .keyAddFailed(let status):

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-import SwiftyRSA
+@testable import SwiftyRSA
 
 class PublicKeyTests: XCTestCase {
     
@@ -19,7 +19,7 @@ class PublicKeyTests: XCTestCase {
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         let publicKey = try PublicKey(data: data)
-
+        
         let newPublicKey = try? PublicKey(reference: publicKey.reference)
         XCTAssertNotNil(newPublicKey)
     }
@@ -248,5 +248,27 @@ class PrivateKeyTests: XCTestCase {
     
     func test_headerAndOctetString() throws {
         _ = try PrivateKey(pemNamed: "swiftyrsa-private-header-octetstring", in: bundle)
+    }
+    
+    //This test will fail and thus has been disabled in the test scheme
+    //it is believed to be because of this bug http://www.openradar.me/36809637
+    @available(iOS 10.0, *)
+    func test_generateKeyPair() throws {
+        let tag = "com.takescoop.SwiftyRSA.PrivateKey"
+        let size = 2048
+        
+        let keyPair = try SwiftyRSA.generateRSAKeyPair(tag: tag, sizeInBits: size, storeInKeyChain: true)
+        XCTAssertNotNil(keyPair)
+        
+        let algorithm: SecKeyAlgorithm = .rsaEncryptionOAEPSHA512
+        guard SecKeyIsAlgorithmSupported(keyPair.privateKey.reference, .decrypt, algorithm) else {
+            XCTFail("Key cannot be used for decryption")
+            return
+        }
+        
+        guard SecKeyIsAlgorithmSupported(keyPair.publicKey.reference, .encrypt, algorithm) else {
+            XCTFail("Key cannot be used for encryption")
+            return
+        }
     }
 }

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -257,7 +257,7 @@ class PrivateKeyTests: XCTestCase {
         let tag = "com.takescoop.SwiftyRSA.PrivateKey"
         let size = 2048
         
-        let keyPair = try SwiftyRSA.generateRSAKeyPair(tag: tag, sizeInBits: size, storeInKeyChain: true)
+        let keyPair = try SwiftyRSA.generateRSAKeyPair(sizeInBits: size)
         XCTAssertNotNil(keyPair)
         
         let algorithm: SecKeyAlgorithm = .rsaEncryptionOAEPSHA512

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -7,7 +7,7 @@
 //
 
 import XCTest
-@testable import SwiftyRSA
+import SwiftyRSA
 
 class PublicKeyTests: XCTestCase {
     
@@ -19,7 +19,6 @@ class PublicKeyTests: XCTestCase {
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
         let publicKey = try PublicKey(data: data)
-        
         let newPublicKey = try? PublicKey(reference: publicKey.reference)
         XCTAssertNotNil(newPublicKey)
     }


### PR DESCRIPTION
The method was added together with an accompanying test, although the test will fail due to what is believed to be a unit test bug http://www.openradar.me/36809637

Apologies for any formatting I've messed up slightly, my Xcode prefs are slightly different.

Let me know if any changes are needed 👍 

Signed-off-by: Christoffer Buusmann <foffer@gmail.com>