### PR TITLE
Modify PublicKey.swift to compile in Swift 4.2 and Xcode 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ SwiftyRSA Changelog
 ===================
 
 # [master]
+- Made compatible with Swift 4.2 and Xcode 10
 
 # [1.4.0]
 

--- a/SwiftyRSA.podspec
+++ b/SwiftyRSA.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.framework = "Security"
   s.requires_arc = true
   
-  s.swift_version = "4.2"
+  s.swift_version = "4.1"
   s.ios.deployment_target = "8.3"
   s.tvos.deployment_target = "9.2"
   s.watchos.deployment_target = "2.2"

--- a/SwiftyRSA.podspec
+++ b/SwiftyRSA.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.framework = "Security"
   s.requires_arc = true
   
-  s.swift_version = "4.1"
+  s.swift_version = "4.2"
   s.ios.deployment_target = "8.3"
   s.tvos.deployment_target = "9.2"
   s.watchos.deployment_target = "2.2"

--- a/SwiftyRSA/PublicKey.swift
+++ b/SwiftyRSA/PublicKey.swift
@@ -100,9 +100,7 @@ public class PublicKey: Key {
             let start = pemString.index(pemString.startIndex, offsetBy: match.location)
             let end = pemString.index(start, offsetBy: match.length)
             
-            let range = Range<String.Index>(start..<end)
-            
-            let thisKey = pemString[range]
+            let thisKey = pemString[start..<end]
             
             return try? PublicKey(pemEncoded: String(thisKey))
         }


### PR DESCRIPTION
This PR makes a small modification required for the project to compile in Swift 4.2 environments. This change does not affect backwards compatibility to Swift 4.1.