### PR TITLE
Remove hashable extension on CFString. Fixes #107

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ SwiftyRSA Changelog
 ===================
 
 # [master]
-- Made compatible with Swift 4.2 and Xcode 10
+
+ - Made compatible with Swift 4.2 and Xcode 10
+ - Fixed a potential crash when building dictionaries with `CFString` values
+   [#107](https://github.com/TakeScoop/SwiftyRSA/issues/107)
 
 # [1.4.0]
 

--- a/SwiftyRSA.xcodeproj/project.pbxproj
+++ b/SwiftyRSA.xcodeproj/project.pbxproj
@@ -781,6 +781,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.takescoop.SwiftyRSATests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
@@ -799,6 +800,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.takescoop.SwiftyRSATests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos watchos watchsimulator";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 4.0;
 			};

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -11,22 +11,6 @@ import Security
 
 public typealias Padding = SecPadding
 
-extension CFString: Hashable {
-    public var hashValue: Int {
-        return (self as String).hashValue
-    }
-    
-    static public func == (lhs: CFString, rhs: CFString) -> Bool {
-        return lhs as String == rhs as String
-    }
-}
-
-extension Data {
-    var hex: String {
-        return map { String(format: "%02hhx", $0) }.joined(separator: " ")
-    }
-}
-
 public enum SwiftyRSA {
     
     static func base64String(pemEncoded pemString: String) throws -> String {
@@ -128,12 +112,12 @@ public enum SwiftyRSA {
     ///   - size: Indicates the total number of bits in this cryptographic key
     /// - Returns: A touple of a private and public key
     /// - Throws: Throws and error if the tag cant be parsed or if keygeneration fails
-    @available(iOS 10.0, *) @available(watchOS 3.0, *) @available(tvOS 10.0, *)
+    @available(iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     public static func generateRSAKeyPair(sizeInBits size: Int) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
         return try generateRSAKeyPair(sizeInBits: size, applyUnitTestWorkaround: false)
     }
     
-    @available(iOS 10.0, *) @available(watchOS 3.0, *) @available(tvOS 10.0, *)
+    @available(iOS 10.0, watchOS 3.0, tvOS 10.0, *)
     static func generateRSAKeyPair(sizeInBits size: Int, applyUnitTestWorkaround: Bool = false) throws -> (privateKey: PrivateKey, publicKey: PublicKey) {
       
         guard let tagData = UUID().uuidString.data(using: .utf8) else {

--- a/SwiftyRSATests/KeyTests.swift
+++ b/SwiftyRSATests/KeyTests.swift
@@ -251,8 +251,11 @@ class PrivateKeyTests: XCTestCase {
         _ = try PrivateKey(pemNamed: "swiftyrsa-private-header-octetstring", in: bundle)
     }
     
-    @available(iOS 10.0, *) @available(watchOS 3.0, *) @available(tvOS 10.0, *)
     func test_generateKeyPair() throws {
+        
+        guard #available(iOS 10.0, watchOS 3.0, tvOS 10.0, *) else {
+            return
+        }
         
         let keyPair = try SwiftyRSA.generateRSAKeyPair(sizeInBits: 2048, applyUnitTestWorkaround: true)
         


### PR DESCRIPTION
Fixes #107 by removing the hashable extension on CFString as it's no longer needed. I believe it was there to cover the `AnyHashable` requirement introduced in Swift 3.0 but that was later removed.

Also fixes a platform compatibility check in unit tests which would run iOS 10 exclusive tests even on iOS 9 platforms.

Waiting on tests to complete and I'll merge directly.