### PR TITLE
Fix SwiftyRSA.SwiftyRSAError.keyAddFailed(-50) on iOS 8-9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ SwiftyRSA Changelog
  - Made compatible with Swift 4.2 and Xcode 10
  - Fixed a potential crash when building dictionaries with `CFString` values
    [#107](https://github.com/TakeScoop/SwiftyRSA/issues/107)
+- Fixed getting `SwiftyRSA.SwiftyRSAError.keyAddFailed(-50)` error when the device is locked on iOS 8 / 9.
 
 # [1.4.0]
 

--- a/SwiftyRSA/SwiftyRSA.swift
+++ b/SwiftyRSA/SwiftyRSA.swift
@@ -188,7 +188,7 @@ public enum SwiftyRSA {
                 kSecValueData: keyData,
                 kSecAttrKeyClass: keyClass,
                 kSecReturnPersistentRef: true,
-                kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock
             ]
             
             let addStatus = SecItemAdd(keyAddDict as CFDictionary, persistKey)
@@ -201,7 +201,7 @@ public enum SwiftyRSA {
                 kSecAttrApplicationTag: tagData,
                 kSecAttrKeyType: kSecAttrKeyTypeRSA,
                 kSecAttrKeyClass: keyClass,
-                kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
+                kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
                 kSecReturnRef: true,
             ]
             


### PR DESCRIPTION
Fixes getting `SwiftyRSA.SwiftyRSAError.keyAddFailed(-50)` error when the iPhone is locked 