### PR TITLE
Added compatiblity for Swift 4.2

### DIFF
--- a/SwiftyRSA/PublicKey.swift
+++ b/SwiftyRSA/PublicKey.swift
@@ -100,7 +100,8 @@ public class PublicKey: Key {
             let start = pemString.index(pemString.startIndex, offsetBy: match.location)
             let end = pemString.index(start, offsetBy: match.length)
             
-            let thisKey = pemString[start..<end]
+            let range: Range<String.Index> = start..<end
+            let thisKey = pemString[range]
             
             return try? PublicKey(pemEncoded: String(thisKey))
         }


### PR DESCRIPTION
Swift 4.2 doesn't include the used Range initializer, so building a project using the pod fails. This PR should fix that and keep backward compatibility. 