### PR TITLE
Fix key generation in command line for MacOS Mojave

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Create public and private RSA keys
 Use `ssh-keygen` to generate a PEM public key and a PEM private key. SwiftyRSA also supports DER public keys.
 
 ```
-$ ssh-keygen -t rsa -f ~/mykey -N ''
+$ ssh-keygen -t rsa -m PEM -f ~/mykey -N ''
 $ cat ~/mykey > ~/private.pem
 $ ssh-keygen -f ~/mykey.pub -e -m pem > ~/public.pem
 ```


### PR DESCRIPTION
Apparently, on MacOS Mojave you need to explicitly specify that you want your private key to be generated in PEM format using `-m PEM` with ssh-keygen.

I was going crazy because I couldn't decrypt anything encrypted using the public key until I found this issue.