### PR TITLE
Bump to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ SwiftyRSA Changelog
 
 # [master]
 
+# [1.6.0]
+
+ - Migrated to minimum requirements of Swift 5.0 and Xcode 10.2.
+
 # [1.5.0]
 
  - Made compatible with Swift 4.2 and Xcode 10
@@ -117,6 +121,7 @@ We recommend to check out the new [usage instructions](./README.md) to migrate c
 Initial release.
 
 [master]: https://github.com/TakeScoop/SwiftyRSA/tree/master
+[1.6.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.6.0
 [1.5.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.5.0
 [1.4.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.4.0
 [1.3.0]: https://github.com/TakeScoop/SwiftyRSA/releases/tag/1.3.0

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 
 ### Swift 5.0+
 
-SwiftyRSA uses Swift 5.0 and requires Xcode 10+.
+SwiftyRSA uses Swift 5.0 and requires Xcode 10.2+.
 
 With Cocoapods:
 

--- a/Source/Info-tvOS.plist
+++ b/Source/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SwiftyRSA.podspec
+++ b/SwiftyRSA.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name = "SwiftyRSA"
-  s.version = "1.5.0"
+  s.version = "1.6.0"
   s.summary = "Public key RSA encryption in Swift."
 
   s.description = <<-DESC
@@ -18,10 +18,10 @@ Pod::Spec.new do |s|
   s.framework = "Security"
   s.requires_arc = true
 
-  s.swift_version = "4.1"
-  s.ios.deployment_target = "8.3"
-  s.tvos.deployment_target = "9.2"
-  s.watchos.deployment_target = "2.2"
+  s.swift_version = "5.0"
+  s.ios.deployment_target = "11.0"
+  s.tvos.deployment_target = "11.0"
+  s.watchos.deployment_target = "5.0"
 
   s.subspec "ObjC" do |sp|
     sp.source_files = "Source/*.{swift,m,h}"


### PR DESCRIPTION
This PR copies the changes from the most recent release commit:

https://github.com/TakeScoop/SwiftyRSA/commit/6160bd5eb4449163b5a90ce5e480de3122efb132

Once this is merged, I'll tag the release and publish the Pod.

A couple of typo fixes are part of this too.  Happy to separate those into a separate PR, if preferred.