### PR TITLE
Minimum Deployment target set to iOS10

### DIFF
--- a/SwiftyRSA.podspec
+++ b/SwiftyRSA.podspec
@@ -19,8 +19,8 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.swift_version = "5.0"
-  s.ios.deployment_target = "11.0"
-  s.tvos.deployment_target = "11.0"
+  s.ios.deployment_target = "10.0"
+  s.tvos.deployment_target = "10.0"
   s.watchos.deployment_target = "5.0"
 
   s.subspec "ObjC" do |sp|


### PR DESCRIPTION
Many apps still support iOS10. Library works fine on iOS10. 
Hence updating it to iOS10

Original Change PR:
https://github.com/TakeScoop/SwiftyRSA/commit/c4f97d7726b5d1cb9480d7e442be4002716d1be9