### PR TITLE
Made iOS target safe for use in app extensions

### DIFF
--- a/SwiftyRSA.xcodeproj/project.pbxproj
+++ b/SwiftyRSA.xcodeproj/project.pbxproj
@@ -661,6 +661,7 @@
 		1D29907DE6801857B21DD3E7B442DC87 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1031,6 +1032,7 @@
 		E9654A97E2EB9CF7CAECB0B96DEC0E9D /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;


### PR DESCRIPTION
The iOS library doesn't use any unsafe API, flagging it as such makes the framework safe for use in extensions.