### PR TITLE
Remove type: .dynamic from Package.swift because it breaks SwiftUI previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     products: [
         .library(
             name: "SwiftyRSA",
-            type: .dynamic,
             targets: ["SwiftyRSA"]),
     ],
     dependencies: [


### PR DESCRIPTION
Hi!

I’m not sure about the decision to make the library use dynamic linking in #231 ([b315992](https://github.com/TakeScoop/SwiftyRSA/pull/231/commits/b315992324b25ea2ecc8fd2c58409626d7922780)). In a comment of earlier PR #197 upon which the accepted PR was based, @bednarj4 [writes](https://github.com/TakeScoop/SwiftyRSA/pull/197#issuecomment-726724180):

> Because for my own purposes I had to make the library dynamic it has to be explicitly marked as delivered with the application

In our project, we switched from building an XCFramework of SwiftyRSA and using it using a binaryTarget in our Package.swift, to adding it as a package depency for one of our packages.

Later, we found that this broke SwiftUI previews, with a confusing error message about SwiftyRSA.framework not being found, despite the package compiling without any problems.

```
PotentialCrashError: Update failed

XCPreviewAgent may have crashed. Check ~/Library/Logs/DiagnosticReports for any crash logs from your application.

==================================

|  RemoteHumanReadableError
|  
|  LoadingError: failed to load library at path "/Users/igs838/Library/Developer/Xcode/DerivedData/SwiftUIPreviewTest-dxlkrksehotjktfjrrlfmsapgtgx/Build/Intermediates.noindex/Previews/SomeModule/Products/Debug-iphonesimulator/PackageFrameworks/SomeModule_-370F8FE6BBB70CFC_PackageProduct.framework/SomeModule_-370F8FE6BBB70CFC_PackageProduct": Optional(dlopen(/Users/igs838/Library/Developer/Xcode/DerivedData/SwiftUIPreviewTest-dxlkrksehotjktfjrrlfmsapgtgx/Build/Intermediates.noindex/Previews/SomeModule/Products/Debug-iphonesimulator/PackageFrameworks/SomeModule_-370F8FE6BBB70CFC_PackageProduct.framework/SomeModule_-370F8FE6BBB70CFC_PackageProduct, 0x0000): Library not loaded: @rpath/SwiftyRSA.framework/SwiftyRSA
|    Referenced from: <45253A62-F7DC-35D8-A81C-4560C60AD9C7> /Users/igs838/Library/Developer/Xcode/DerivedData/SwiftUIPreviewTest-dxlkrksehotjktfjrrlfmsapgtgx/Build/Intermediates.noindex/Previews/SomeModule/Products/Debug-iphonesimulator/PackageFrameworks/SomeModule_-370F8FE6BBB70CFC_PackageProduct.framework/SomeModule_-370F8FE6BBB70CFC_PackageProduct
|    Reason: tried: '/Users/igs838/Library/Developer/Xcode/DerivedData/SwiftUIPreviewTest-dxlkrksehotjktfjrrlfmsapgtgx/Build/Intermediates.noindex/Previews/SomeModule/Products/Debug-iphonesimulator/SwiftyRSA.framework/SwiftyRSA' (errno=2), '/Applications/Xcode-14.2.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/SwiftyRSA.framework/SwiftyRSA' (errno=2), '/usr/lib/swift/SwiftyRSA.framework/SwiftyRSA' (errno=2, not in dyld cache), '/Applications/Xcode-14.2.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift/SwiftyRSA.framework/SwiftyRSA' (errno=2), '/usr/lib/swift/SwiftyRSA.framework/SwiftyRSA' (errno=2, not in dyld cache), '/Applications/Xcode-14.2.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/Frameworks/SwiftyRSA.framework/SwiftyRSA' (errno=2))
|  
|  ==================================
|  
|  |  MessageSendFailure: Message send failure for <ServiceMessage 159: update>
```

I verified this by creating a project from scratch with just a Swift package with a SwiftUI view. Previews were broken when adding SwiftyRSA (1.8.0) as a (package) dependency, but worked when I instead referenced this fork where I had removed the *type* argument.

If I understand correctly, Apple’s position is that you typically should not use this parameter. The [Swift Package Manager documentation says](https://developer.apple.com/documentation/packagedescription/product/library(name:type:targets:)): 

> It’s recommended that you don’t explicitly declare the type of library, so Swift Package Manager can choose between static or dynamic linking based on the preference of the package’s consumer.

Unless there’s some specific reason why this must use dynamic linking, perhaps this can be removed?
