### PR TITLE
Fix warning in Swift 5.8

### DIFF
--- a/Source/SwiftyRSA.swift
+++ b/Source/SwiftyRSA.swift
@@ -136,7 +136,7 @@ public enum SwiftyRSA {
             kSecPrivateKeyAttrs: [
                 kSecAttrIsPermanent: isPermanent,
                 kSecAttrApplicationTag: tagData
-            ]
+            ] as [CFString: Any]
         ]
         
         var error: Unmanaged<CFError>?


### PR DESCRIPTION
```
Source/SwiftyRSA.swift:136:34: warning: heterogeneous collection literal could only be inferred to '[CFString : Any]'; add explicit type annotation if this is intentional
            kSecPrivateKeyAttrs: [
                                 ^
```