### PR TITLE
Renaming PublicKey and PrivateKey Classes

### DIFF
--- a/Source/ClearMessage.swift
+++ b/Source/ClearMessage.swift
@@ -53,7 +53,7 @@ public class ClearMessage: Message {
     ///   - padding: Padding to use during the encryption
     /// - Returns: Encrypted message
     /// - Throws: SwiftyRSAError
-    public func encrypted(with key: PublicKey, padding: Padding) throws -> EncryptedMessage {
+    public func encrypted(with key: SwiftyRSA.PublicKey, padding: Padding) throws -> EncryptedMessage {
         
         let blockSize = SecKeyGetBlockSize(key.reference)
         
@@ -104,7 +104,7 @@ public class ClearMessage: Message {
     ///   - digestType: Digest
     /// - Returns: Signature of the clear message after signing it with the specified digest type.
     /// - Throws: SwiftyRSAError
-    public func signed(with key: PrivateKey, digestType: Signature.DigestType) throws -> Signature {
+    public func signed(with key: SwiftyRSA.PrivateKey, digestType: Signature.DigestType) throws -> Signature {
         
         let digest = self.digest(digestType: digestType)
         let blockSize = SecKeyGetBlockSize(key.reference)
@@ -138,7 +138,7 @@ public class ClearMessage: Message {
     ///   - digestType: Digest type used for the signature
     /// - Returns: Result of the verification
     /// - Throws: SwiftyRSAError
-    public func verify(with key: PublicKey, signature: Signature, digestType: Signature.DigestType) throws -> Bool {
+    public func verify(with key: SwiftyRSA.PublicKey, signature: Signature, digestType: Signature.DigestType) throws -> Bool {
         
         let digest = self.digest(digestType: digestType)
         var digestBytes = [UInt8](repeating: 0, count: digest.count)

--- a/Source/EncryptedMessage.swift
+++ b/Source/EncryptedMessage.swift
@@ -27,7 +27,7 @@ public class EncryptedMessage: Message {
     ///   - padding: Padding to use during the decryption
     /// - Returns: Clear message
     /// - Throws: SwiftyRSAError
-    public func decrypted(with key: PrivateKey, padding: Padding) throws -> ClearMessage {
+    public func decrypted(with key: SwiftyRSA.PrivateKey, padding: Padding) throws -> ClearMessage {
         let blockSize = SecKeyGetBlockSize(key.reference)
         
         var encryptedDataAsArray = [UInt8](repeating: 0, count: data.count)

--- a/Source/PrivateKey.swift
+++ b/Source/PrivateKey.swift
@@ -7,59 +7,61 @@
 //
 
 import Foundation
+public extension SwiftyRSA {
+    class PrivateKey: Key {
+        
+        /// Reference to the key within the keychain
+        public let reference: SecKey
+        
+        /// Original data of the private key.
+        /// Note that it does not contain PEM headers and holds data as bytes, not as a base 64 string.
+        public let originalData: Data?
+        
+        let tag: String?
+        
+        /// Returns a PEM representation of the private key.
+        ///
+        /// - Returns: Data of the key, PEM-encoded
+        /// - Throws: SwiftyRSAError
+        public func pemString() throws -> String {
+            let data = try self.data()
+            let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PRIVATE KEY")
+            return pem
+        }
+        
+        /// Creates a private key with a keychain key reference.
+        /// This initializer will throw if the provided key reference is not a private RSA key.
+        ///
+        /// - Parameter reference: Reference to the key within the keychain.
+        /// - Throws: SwiftyRSAError
+        public required init(reference: SecKey) throws {
+            
+            guard SwiftyRSA.isValidKeyReference(reference, forClass: kSecAttrKeyClassPrivate) else {
+                throw SwiftyRSAError.notAPrivateKey
+            }
+            
+            self.reference = reference
+            self.tag = nil
+            self.originalData = nil
+        }
+        
+        /// Creates a private key with a RSA public key data.
+        ///
+        /// - Parameter data: Private key data
+        /// - Throws: SwiftyRSAError
+        required public init(data: Data) throws {
+            self.originalData = data
+            let tag = UUID().uuidString
+            self.tag = tag
+            let dataWithoutHeader = try SwiftyRSA.stripKeyHeader(keyData: data)
+            reference = try SwiftyRSA.addKey(dataWithoutHeader, isPublic: false, tag: tag)
+        }
+        
+        deinit {
+            if let tag = tag {
+                SwiftyRSA.removeKey(tag: tag)
+            }
+        }
+    }
 
-public class PrivateKey: Key {
-    
-    /// Reference to the key within the keychain
-    public let reference: SecKey
-    
-    /// Original data of the private key.
-    /// Note that it does not contain PEM headers and holds data as bytes, not as a base 64 string.
-    public let originalData: Data?
-    
-    let tag: String?
-    
-    /// Returns a PEM representation of the private key.
-    ///
-    /// - Returns: Data of the key, PEM-encoded
-    /// - Throws: SwiftyRSAError
-    public func pemString() throws -> String {
-        let data = try self.data()
-        let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PRIVATE KEY")
-        return pem
-    }
-    
-    /// Creates a private key with a keychain key reference.
-    /// This initializer will throw if the provided key reference is not a private RSA key.
-    ///
-    /// - Parameter reference: Reference to the key within the keychain.
-    /// - Throws: SwiftyRSAError
-    public required init(reference: SecKey) throws {
-        
-        guard SwiftyRSA.isValidKeyReference(reference, forClass: kSecAttrKeyClassPrivate) else {
-            throw SwiftyRSAError.notAPrivateKey
-        }
-        
-        self.reference = reference
-        self.tag = nil
-        self.originalData = nil
-    }
-    
-    /// Creates a private key with a RSA public key data.
-    ///
-    /// - Parameter data: Private key data
-    /// - Throws: SwiftyRSAError
-    required public init(data: Data) throws {
-        self.originalData = data
-        let tag = UUID().uuidString
-        self.tag = tag
-        let dataWithoutHeader = try SwiftyRSA.stripKeyHeader(keyData: data)
-        reference = try SwiftyRSA.addKey(dataWithoutHeader, isPublic: false, tag: tag)
-    }
-    
-    deinit {
-        if let tag = tag {
-            SwiftyRSA.removeKey(tag: tag)
-        }
-    }
 }

--- a/Source/PublicKey.swift
+++ b/Source/PublicKey.swift
@@ -8,109 +8,112 @@
 
 import Foundation
 
-public class PublicKey: Key {
-    
-    /// Reference to the key within the keychain
-    public let reference: SecKey
-    
-    /// Data of the public key as provided when creating the key.
-    /// Note that if the key was created from a base64string / DER string / PEM file / DER file,
-    /// the data holds the actual bytes of the key, not any textual representation like PEM headers
-    /// or base64 characters.
-    public let originalData: Data?
-    
-    let tag: String? // Only used on iOS 8/9
-    
-    /// Returns a PEM representation of the public key.
-    ///
-    /// - Returns: Data of the key, PEM-encoded
-    /// - Throws: SwiftyRSAError
-    public func pemString() throws -> String {
-        let data = try self.data()
-        let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PUBLIC KEY")
-        return pem
-    }
-    
-    /// Creates a public key with a keychain key reference.
-    /// This initializer will throw if the provided key reference is not a public RSA key.
-    ///
-    /// - Parameter reference: Reference to the key within the keychain.
-    /// - Throws: SwiftyRSAError
-    public required init(reference: SecKey) throws {
+public extension SwiftyRSA {
+    class PublicKey: Key {
         
-        guard SwiftyRSA.isValidKeyReference(reference, forClass: kSecAttrKeyClassPublic) else {
-            throw SwiftyRSAError.notAPublicKey
+        /// Reference to the key within the keychain
+        public let reference: SecKey
+        
+        /// Data of the public key as provided when creating the key.
+        /// Note that if the key was created from a base64string / DER string / PEM file / DER file,
+        /// the data holds the actual bytes of the key, not any textual representation like PEM headers
+        /// or base64 characters.
+        public let originalData: Data?
+        
+        let tag: String? // Only used on iOS 8/9
+        
+        /// Returns a PEM representation of the public key.
+        ///
+        /// - Returns: Data of the key, PEM-encoded
+        /// - Throws: SwiftyRSAError
+        public func pemString() throws -> String {
+            let data = try self.data()
+            let pem = SwiftyRSA.format(keyData: data, withPemType: "RSA PUBLIC KEY")
+            return pem
         }
         
-        self.reference = reference
-        self.tag = nil
-        self.originalData = nil
-    }
-    
-    /// Data of the public key as returned by the keychain.
-    /// This method throws if SwiftyRSA cannot extract data from the key.
-    ///
-    /// - Returns: Data of the public key as returned by the keychain.
-    /// - Throws: SwiftyRSAError
-    required public init(data: Data) throws {
-        
-        let tag = UUID().uuidString
-        self.tag = tag
-        
-        self.originalData = data
-        let dataWithoutHeader = try SwiftyRSA.stripKeyHeader(keyData: data)
-        
-        reference = try SwiftyRSA.addKey(dataWithoutHeader, isPublic: true, tag: tag)
-    }
-    
-    static let publicKeyRegex: NSRegularExpression? = {
-        let publicKeyRegex = "(-----BEGIN PUBLIC KEY-----.+?-----END PUBLIC KEY-----)"
-        return try? NSRegularExpression(pattern: publicKeyRegex, options: .dotMatchesLineSeparators)
-    }()
-    
-    /// Takes an input string, scans for public key sections, and then returns a PublicKey for any valid keys found
-    /// - This method scans the file for public key armor - if no keys are found, an empty array is returned
-    /// - Each public key block found is "parsed" by `publicKeyFromPEMString()`
-    /// - should that method throw, the error is _swallowed_ and not rethrown
-    ///
-    /// - parameter pemString: The string to use to parse out values
-    ///
-    /// - returns: An array of `PublicKey` objects
-    public static func publicKeys(pemEncoded pemString: String) -> [PublicKey] {
-        
-        // If our regexp isn't valid, or the input string is empty, we can't move forward…
-        guard let publicKeyRegexp = publicKeyRegex, pemString.count > 0 else {
-            return []
-        }
-        
-        let all = NSRange(
-            location: 0,
-            length: pemString.count
-        )
-        
-        let matches = publicKeyRegexp.matches(
-            in: pemString,
-            options: NSRegularExpression.MatchingOptions(rawValue: 0),
-            range: all
-        )
-        
-        let keys = matches.compactMap { result -> PublicKey? in
+        /// Creates a public key with a keychain key reference.
+        /// This initializer will throw if the provided key reference is not a public RSA key.
+        ///
+        /// - Parameter reference: Reference to the key within the keychain.
+        /// - Throws: SwiftyRSAError
+        public required init(reference: SecKey) throws {
             
-            let match = result.range(at: 1)
-            let start = pemString.index(pemString.startIndex, offsetBy: match.location)
-            let end = pemString.index(start, offsetBy: match.length)
+            guard SwiftyRSA.isValidKeyReference(reference, forClass: kSecAttrKeyClassPublic) else {
+                throw SwiftyRSAError.notAPublicKey
+            }
             
-            let thisKey = pemString[start..<end]
-            
-            return try? PublicKey(pemEncoded: String(thisKey))
+            self.reference = reference
+            self.tag = nil
+            self.originalData = nil
         }
         
-        return keys
-    }
-    
-    deinit {
-        if let tag = tag {
-            SwiftyRSA.removeKey(tag: tag)
+        /// Data of the public key as returned by the keychain.
+        /// This method throws if SwiftyRSA cannot extract data from the key.
+        ///
+        /// - Returns: Data of the public key as returned by the keychain.
+        /// - Throws: SwiftyRSAError
+        required public init(data: Data) throws {
+            
+            let tag = UUID().uuidString
+            self.tag = tag
+            
+            self.originalData = data
+            let dataWithoutHeader = try SwiftyRSA.stripKeyHeader(keyData: data)
+            
+            reference = try SwiftyRSA.addKey(dataWithoutHeader, isPublic: true, tag: tag)
+        }
+        
+        static let publicKeyRegex: NSRegularExpression? = {
+            let publicKeyRegex = "(-----BEGIN PUBLIC KEY-----.+?-----END PUBLIC KEY-----)"
+            return try? NSRegularExpression(pattern: publicKeyRegex, options: .dotMatchesLineSeparators)
+        }()
+        
+        /// Takes an input string, scans for public key sections, and then returns a PublicKey for any valid keys found
+        /// - This method scans the file for public key armor - if no keys are found, an empty array is returned
+        /// - Each public key block found is "parsed" by `publicKeyFromPEMString()`
+        /// - should that method throw, the error is _swallowed_ and not rethrown
+        ///
+        /// - parameter pemString: The string to use to parse out values
+        ///
+        /// - returns: An array of `PublicKey` objects
+        public static func publicKeys(pemEncoded pemString: String) -> [PublicKey] {
+            
+            // If our regexp isn't valid, or the input string is empty, we can't move forward…
+            guard let publicKeyRegexp = publicKeyRegex, pemString.count > 0 else {
+                return []
+            }
+            
+            let all = NSRange(
+                location: 0,
+                length: pemString.count
+            )
+            
+            let matches = publicKeyRegexp.matches(
+                in: pemString,
+                options: NSRegularExpression.MatchingOptions(rawValue: 0),
+                range: all
+            )
+            
+            let keys = matches.compactMap { result -> PublicKey? in
+                
+                let match = result.range(at: 1)
+                let start = pemString.index(pemString.startIndex, offsetBy: match.location)
+                let end = pemString.index(start, offsetBy: match.length)
+                
+                let thisKey = pemString[start..<end]
+                
+                return try? PublicKey(pemEncoded: String(thisKey))
+            }
+            
+            return keys
+        }
+        
+        deinit {
+            if let tag = tag {
+                SwiftyRSA.removeKey(tag: tag)
+            }
         }
     }
+
 }

--- a/Source/SwiftyRSA+ObjC.swift
+++ b/Source/SwiftyRSA+ObjC.swift
@@ -49,7 +49,7 @@ public class _objc_SwiftyRSA: NSObject { // swiftlint:disable:this type_name
 
 // MARK: - PublicKey
 
-@objc(PublicKey)
+@objc(ObjcPublicKey)
 public class _objc_PublicKey: NSObject, Key, ObjcBridgeable { // swiftlint:disable:this type_name
     
     fileprivate let swiftValue: SwiftyRSA.PublicKey

--- a/Source/SwiftyRSA+ObjC.swift
+++ b/Source/SwiftyRSA+ObjC.swift
@@ -52,7 +52,7 @@ public class _objc_SwiftyRSA: NSObject { // swiftlint:disable:this type_name
 @objc(PublicKey)
 public class _objc_PublicKey: NSObject, Key, ObjcBridgeable { // swiftlint:disable:this type_name
     
-    fileprivate let swiftValue: PublicKey
+    fileprivate let swiftValue: SwiftyRSA.PublicKey
     
     @objc public var reference: SecKey {
         return swiftValue.reference
@@ -74,36 +74,36 @@ public class _objc_PublicKey: NSObject, Key, ObjcBridgeable { // swiftlint:disab
         return try swiftValue.base64String()
     }
     
-    required public init(swiftValue: PublicKey) {
+    required public init(swiftValue: SwiftyRSA.PublicKey) {
         self.swiftValue = swiftValue
     }
     
     @objc required public init(data: Data) throws {
-        self.swiftValue = try PublicKey(data: data)
+        self.swiftValue = try SwiftyRSA.PublicKey(data: data)
     }
     
     @objc public required init(reference: SecKey) throws {
-        self.swiftValue = try PublicKey(reference: reference)
+        self.swiftValue = try SwiftyRSA.PublicKey(reference: reference)
     }
     
     @objc public required init(base64Encoded base64String: String) throws {
-        self.swiftValue = try PublicKey(base64Encoded: base64String)
+        self.swiftValue = try SwiftyRSA.PublicKey(base64Encoded: base64String)
     }
     
     @objc public required init(pemEncoded pemString: String) throws {
-        self.swiftValue = try PublicKey(pemEncoded: pemString)
+        self.swiftValue = try SwiftyRSA.PublicKey(pemEncoded: pemString)
     }
     
     @objc public required init(pemNamed pemName: String, in bundle: Bundle) throws {
-        self.swiftValue = try PublicKey(pemNamed: pemName, in: bundle)
+        self.swiftValue = try SwiftyRSA.PublicKey(pemNamed: pemName, in: bundle)
     }
     
     @objc public required init(derNamed derName: String, in bundle: Bundle) throws {
-        self.swiftValue = try PublicKey(derNamed: derName, in: bundle)
+        self.swiftValue = try SwiftyRSA.PublicKey(derNamed: derName, in: bundle)
     }
     
     @objc public static func publicKeys(pemEncoded pemString: String) -> [_objc_PublicKey] {
-        return PublicKey.publicKeys(pemEncoded: pemString).map { _objc_PublicKey(swiftValue: $0) }
+        return SwiftyRSA.PublicKey.publicKeys(pemEncoded: pemString).map { _objc_PublicKey(swiftValue: $0) }
     }
 }
 
@@ -112,7 +112,7 @@ public class _objc_PublicKey: NSObject, Key, ObjcBridgeable { // swiftlint:disab
 @objc(PrivateKey)
 public class _objc_PrivateKey: NSObject, Key, ObjcBridgeable { // swiftlint:disable:this type_name
     
-    fileprivate let swiftValue: PrivateKey
+    fileprivate let swiftValue: SwiftyRSA.PrivateKey
     
     @objc public var reference: SecKey {
         return swiftValue.reference
@@ -134,32 +134,32 @@ public class _objc_PrivateKey: NSObject, Key, ObjcBridgeable { // swiftlint:disa
         return try swiftValue.base64String()
     }
     
-    public required init(swiftValue: PrivateKey) {
+    public required init(swiftValue: SwiftyRSA.PrivateKey) {
         self.swiftValue = swiftValue
     }
     
     @objc public required init(data: Data) throws {
-        self.swiftValue = try PrivateKey(data: data)
+        self.swiftValue = try SwiftyRSA.PrivateKey(data: data)
     }
     
     @objc public required init(reference: SecKey) throws {
-        self.swiftValue = try PrivateKey(reference: reference)
+        self.swiftValue = try SwiftyRSA.PrivateKey(reference: reference)
     }
     
     @objc public required init(base64Encoded base64String: String) throws {
-        self.swiftValue = try PrivateKey(base64Encoded: base64String)
+        self.swiftValue = try SwiftyRSA.PrivateKey(base64Encoded: base64String)
     }
     
     @objc public required init(pemEncoded pemString: String) throws {
-        self.swiftValue = try PrivateKey(pemEncoded: pemString)
+        self.swiftValue = try SwiftyRSA.PrivateKey(pemEncoded: pemString)
     }
     
     @objc public required init(pemNamed pemName: String, in bundle: Bundle) throws {
-        self.swiftValue = try PrivateKey(pemNamed: pemName, in: bundle)
+        self.swiftValue = try SwiftyRSA.PrivateKey(pemNamed: pemName, in: bundle)
     }
     
     @objc public required init(derNamed derName: String, in bundle: Bundle) throws {
-        self.swiftValue = try PrivateKey(derNamed: derName, in: bundle)
+        self.swiftValue = try SwiftyRSA.PrivateKey(derNamed: derName, in: bundle)
     }
 }
 

--- a/Source/SwiftyRSA.swift
+++ b/Source/SwiftyRSA.swift
@@ -144,8 +144,8 @@ public enum SwiftyRSA {
             let pubKey = SecKeyCopyPublicKey(privKey) else {
             throw SwiftyRSAError.keyGenerationFailed(error: error?.takeRetainedValue())
         }
-        let privateKey = try PrivateKey(reference: privKey)
-        let publicKey = try PublicKey(reference: pubKey)
+        let privateKey = try SwiftyRSA.PrivateKey(reference: privKey)
+        let publicKey = try SwiftyRSA.PublicKey(reference: pubKey)
         
         return (privateKey: privateKey, publicKey: publicKey)
     }

--- a/Tests/EncryptDecryptTests.swift
+++ b/Tests/EncryptDecryptTests.swift
@@ -76,8 +76,8 @@ class EncryptDecryptTests: XCTestCase {
         let data = TestUtils.randomData(count: 2048)
         let clearMessage = ClearMessage(data: data)
         
-        let newPublicKey = try PublicKey(reference: publicKey.reference)
-        let newPrivateKey = try PrivateKey(reference: privateKey.reference)
+        let newPublicKey = try SwiftyRSA.PublicKey(reference: publicKey.reference)
+        let newPrivateKey = try SwiftyRSA.PrivateKey(reference: privateKey.reference)
         
         // Encrypt with old public key, decrypt with old private key
         do {
@@ -113,8 +113,8 @@ class EncryptDecryptTests: XCTestCase {
         let data = TestUtils.randomData(count: 2048)
         let clearMessage = ClearMessage(data: data)
         
-        let newPublicKey = try PublicKey(data: try publicKey.data())
-        let newPrivateKey = try PrivateKey(data: try privateKey.data())
+        let newPublicKey = try SwiftyRSA.PublicKey(data: try publicKey.data())
+        let newPrivateKey = try SwiftyRSA.PrivateKey(data: try privateKey.data())
         
         // Encrypt with old public key, decrypt with old private key
         do {

--- a/Tests/KeyTests.swift
+++ b/Tests/KeyTests.swift
@@ -20,8 +20,8 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let publicKey = try PublicKey(data: data)
-        let newPublicKey = try? PublicKey(reference: publicKey.reference)
+        let publicKey = try SwiftyRSA.PublicKey(data: data)
+        let newPublicKey = try? SwiftyRSA.PublicKey(reference: publicKey.reference)
         XCTAssertNotNil(newPublicKey)
     }
     
@@ -36,10 +36,10 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let privateKey = try PrivateKey(pemEncoded: str)
+        let privateKey = try SwiftyRSA.PrivateKey(pemEncoded: str)
         
         TestUtils.assertThrows(type: SwiftyRSAError.notAPublicKey) {
-            _ = try PublicKey(reference: privateKey.reference)
+            _ = try SwiftyRSA.PublicKey(reference: privateKey.reference)
         }
     }
     
@@ -48,7 +48,7 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let publicKey = try? PublicKey(data: data)
+        let publicKey = try? SwiftyRSA.PublicKey(data: data)
         XCTAssertNotNil(publicKey)
     }
     
@@ -57,7 +57,7 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let publicKey = try? PublicKey(base64Encoded: str)
+        let publicKey = try? SwiftyRSA.PublicKey(base64Encoded: str)
         XCTAssertNotNil(publicKey)
     }
     
@@ -66,7 +66,7 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let publicKey = try? PublicKey(base64Encoded: str)
+        let publicKey = try? SwiftyRSA.PublicKey(base64Encoded: str)
         XCTAssertNotNil(publicKey)
     }
     
@@ -75,17 +75,17 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let publicKey = try? PublicKey(pemEncoded: str)
+        let publicKey = try? SwiftyRSA.PublicKey(pemEncoded: str)
         XCTAssertNotNil(publicKey)
     }
     
     func test_initWithPEMName() throws {
-        let publicKey = try? PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let publicKey = try? SwiftyRSA.PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
         XCTAssertNotNil(publicKey)
     }
     
     func test_initWithDERName() throws {
-        let publicKey = try? PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let publicKey = try? SwiftyRSA.PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
         XCTAssertNotNil(publicKey)
     }
     
@@ -94,24 +94,24 @@ class PublicKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let publicKey = try? PublicKey(pemEncoded: str)
+        let publicKey = try? SwiftyRSA.PublicKey(pemEncoded: str)
         XCTAssertNotNil(publicKey)
     }
     
     func test_publicKeysFromComplexPEMFileWorksCorrectly() {
         let input = TestUtils.pemKeyString(name: "multiple-keys-testcase")
-        let keys = PublicKey.publicKeys(pemEncoded: input)
+        let keys = SwiftyRSA.PublicKey.publicKeys(pemEncoded: input)
         XCTAssertEqual(keys.count, 9)
     }
     
     func test_publicKeysFromEmptyPEMFileReturnsEmptyArray() {
-        let keys = PublicKey.publicKeys(pemEncoded: "")
+        let keys = SwiftyRSA.PublicKey.publicKeys(pemEncoded: "")
         XCTAssertEqual(keys.count, 0)
     }
     
     func test_publicKeysFromPrivateKeyPEMFileReturnsEmptyArray() {
         let input = TestUtils.pemKeyString(name: "swiftyrsa-private")
-        let keys = PublicKey.publicKeys(pemEncoded: input)
+        let keys = SwiftyRSA.PublicKey.publicKeys(pemEncoded: input)
         XCTAssertEqual(keys.count, 0)
     }
     
@@ -123,7 +123,7 @@ class PublicKeyTests: XCTestCase {
                 return XCTFail("file not found in bundle")
             }
             let data = try Data(contentsOf: URL(fileURLWithPath: path))
-            let publicKey = try PublicKey(data: data)
+            let publicKey = try SwiftyRSA.PublicKey(data: data)
             
             guard let dataFromKeychain = try? publicKey.data() else {
                 return XCTFail("file not found in bundle")
@@ -139,24 +139,24 @@ class PublicKeyTests: XCTestCase {
                 return XCTFail("file not found in bundle")
             }
             let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-            let publicKey = try PublicKey(pemEncoded: str)
+            let publicKey = try SwiftyRSA.PublicKey(pemEncoded: str)
             XCTAssertNotNil(publicKey.originalData)
             XCTAssertNotNil(try? publicKey.data())
         }
     }
     
     func test_pemString() throws {
-        let publicKey = try PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let publicKey = try SwiftyRSA.PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
         let pemString = try publicKey.pemString()
-        let newPublicKey = try PublicKey(pemEncoded: pemString)
+        let newPublicKey = try SwiftyRSA.PublicKey(pemEncoded: pemString)
         XCTAssertNotNil(newPublicKey)
         XCTAssertEqual(try? publicKey.data(), try? newPublicKey.data())
     }
     
     func test_base64String() throws {
-        let publicKey = try PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
+        let publicKey = try SwiftyRSA.PublicKey(pemNamed: "swiftyrsa-public", in: bundle)
         let base64String = try publicKey.base64String()
-        let newPublicKey = try PublicKey(base64Encoded: base64String)
+        let newPublicKey = try SwiftyRSA.PublicKey(base64Encoded: base64String)
         XCTAssertNotNil(newPublicKey)
         XCTAssertEqual(try? publicKey.data(), try? newPublicKey.data())
     }
@@ -171,9 +171,9 @@ class PrivateKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let privateKey = try PrivateKey(pemEncoded: str)
+        let privateKey = try SwiftyRSA.PrivateKey(pemEncoded: str)
         
-        let newPrivateKey = try? PrivateKey(reference: privateKey.reference)
+        let newPrivateKey = try? SwiftyRSA.PrivateKey(reference: privateKey.reference)
         XCTAssertNotNil(newPrivateKey)
     }
     
@@ -188,10 +188,10 @@ class PrivateKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let publicKey = try PublicKey(data: data)
+        let publicKey = try SwiftyRSA.PublicKey(data: data)
         
         TestUtils.assertThrows(type: SwiftyRSAError.notAPrivateKey) {
-            _ = try PrivateKey(reference: publicKey.reference)
+            _ = try SwiftyRSA.PrivateKey(reference: publicKey.reference)
         }
     }
     
@@ -200,7 +200,7 @@ class PrivateKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let privateKey = try? PrivateKey(pemEncoded: str)
+        let privateKey = try? SwiftyRSA.PrivateKey(pemEncoded: str)
         XCTAssertNotNil(privateKey)
     }
     
@@ -209,17 +209,17 @@ class PrivateKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        let privateKey = try? PrivateKey(pemEncoded: str)
+        let privateKey = try? SwiftyRSA.PrivateKey(pemEncoded: str)
         XCTAssertNotNil(privateKey)
     }
     
     func test_initWithPEMName() throws {
-        let message = try? PrivateKey(pemNamed: "swiftyrsa-private", in: Bundle(for: TestUtils.self))
+        let message = try? SwiftyRSA.PrivateKey(pemNamed: "swiftyrsa-private", in: Bundle(for: TestUtils.self))
         XCTAssertNotNil(message)
     }
     
     func test_initWithDERName() throws {
-        let message = try? PrivateKey(pemNamed: "swiftyrsa-private", in: Bundle(for: TestUtils.self))
+        let message = try? SwiftyRSA.PrivateKey(pemNamed: "swiftyrsa-private", in: Bundle(for: TestUtils.self))
         XCTAssertNotNil(message)
     }
     
@@ -228,27 +228,27 @@ class PrivateKeyTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let data = try Data(contentsOf: URL(fileURLWithPath: path))
-        let publicKey = try PrivateKey(data: data)
+        let publicKey = try SwiftyRSA.PrivateKey(data: data)
         XCTAssertEqual(try? publicKey.data(), data)
     }
     
     func test_pemString() throws {
-        let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
+        let privateKey = try SwiftyRSA.PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
         let pemString = try privateKey.pemString()
-        let newPrivateKey = try PrivateKey(pemEncoded: pemString)
+        let newPrivateKey = try SwiftyRSA.PrivateKey(pemEncoded: pemString)
         XCTAssertNotNil(newPrivateKey)
         XCTAssertEqual(try? privateKey.data(), try? newPrivateKey.data())
     }
     
     func test_base64String() throws {
-        let privateKey = try PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
+        let privateKey = try SwiftyRSA.PrivateKey(pemNamed: "swiftyrsa-private", in: bundle)
         let base64String = try privateKey.base64String()
-        let newPrivateKey = try PrivateKey(base64Encoded: base64String)
+        let newPrivateKey = try SwiftyRSA.PrivateKey(base64Encoded: base64String)
         XCTAssertEqual(try? privateKey.data(), try? newPrivateKey.data())
     }
     
     func test_headerAndOctetString() throws {
-        _ = try PrivateKey(pemNamed: "swiftyrsa-private-header-octetstring", in: bundle)
+        _ = try SwiftyRSA.PrivateKey(pemNamed: "swiftyrsa-private-header-octetstring", in: bundle)
     }
     
     func test_generateKeyPair() throws {

--- a/Tests/TestUtils.swift
+++ b/Tests/TestUtils.swift
@@ -31,12 +31,12 @@ struct TestError: Error {
     }
     
     @nonobjc
-    static public func publicKey(name: String) throws -> PublicKey {
+    static public func publicKey(name: String) throws -> SwiftyRSA.PublicKey {
         guard let path = bundle.path(forResource: name, ofType: "pem") else {
             throw TestError(description: "Couldn't load key for provided path")
         }
         let pemString = try String(contentsOf: URL(fileURLWithPath: path))
-        return try PublicKey(pemEncoded: pemString)
+        return try SwiftyRSA.PublicKey(pemEncoded: pemString)
     }
     
     @objc(publicKeyWithName:error:)
@@ -49,12 +49,12 @@ struct TestError: Error {
     }
     
     @nonobjc
-    static public func privateKey(name: String) throws -> PrivateKey {
+    static public func privateKey(name: String) throws -> SwiftyRSA.PrivateKey {
         guard let path = bundle.path(forResource: name, ofType: "pem") else {
             throw TestError(description: "Couldn't load key for provided path")
         }
         let pemString = try String(contentsOf: URL(fileURLWithPath: path))
-        return try PrivateKey(pemEncoded: pemString)
+        return try SwiftyRSA.PrivateKey(pemEncoded: pemString)
     }
     
     @objc(privateKeyWithName:error:)

--- a/Tests/X509Tests.swift
+++ b/Tests/X509Tests.swift
@@ -52,7 +52,7 @@ class X509CertificateTests: XCTestCase {
             return XCTFail("file not found in bundle")
         }
         let str = try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
-        if let publicKey = try? PublicKey(base64Encoded: str) { // Creating a public key strip the X509 header
+        if let publicKey = try? SwiftyRSA.PublicKey(base64Encoded: str) { // Creating a public key strip the X509 header
             let publicKey509 = try SwiftyRSA.prependX509KeyHeader(keyData: publicKey.data())
             let publicKey509Base64 = publicKey509.base64EncodedString()
             XCTAssertEqual(publicKey509Base64, str)
@@ -98,8 +98,8 @@ class X509CertificateTests: XCTestCase {
         let clear = "Hello world !"
         let clearMessage = try ClearMessage(string: clear, using: .utf8)
         
-        let encrypted = try clearMessage.encrypted(with: PublicKey(data: publicKeyX509), padding: .PKCS1)
-        let decrypted = try encrypted.decrypted(with: PrivateKey(data: privateKeyX509), padding: .PKCS1)
+        let encrypted = try clearMessage.encrypted(with: SwiftyRSA.PublicKey(data: publicKeyX509), padding: .PKCS1)
+        let decrypted = try encrypted.decrypted(with: SwiftyRSA.PrivateKey(data: privateKeyX509), padding: .PKCS1)
         
         XCTAssertEqual(try? decrypted.string(encoding: .utf8), clear)
     }
@@ -116,8 +116,8 @@ class X509CertificateTests: XCTestCase {
         let clear = [String](repeating: "a", count: 9999).joined(separator: "")
         let clearMessage = try ClearMessage(string: clear, using: .utf8)
         
-        let encrypted = try clearMessage.encrypted(with: PublicKey(data: publicKeyX509), padding: .PKCS1)
-        let decrypted = try encrypted.decrypted(with: PrivateKey(data: privateKeyX509), padding: .PKCS1)
+        let encrypted = try clearMessage.encrypted(with: SwiftyRSA.PublicKey(data: publicKeyX509), padding: .PKCS1)
+        let decrypted = try encrypted.decrypted(with: SwiftyRSA.PrivateKey(data: privateKeyX509), padding: .PKCS1)
         
         XCTAssertEqual(try? decrypted.string(encoding: .utf8), clear)
     }
@@ -134,8 +134,8 @@ class X509CertificateTests: XCTestCase {
         let data = TestUtils.randomData(count: 2048)
         let clearMessage = ClearMessage(data: data)
         
-        let encrypted = try clearMessage.encrypted(with: PublicKey(data: publicKeyX509), padding: .PKCS1)
-        let decrypted = try encrypted.decrypted(with: PrivateKey(data: privateKeyX509), padding: .PKCS1)
+        let encrypted = try clearMessage.encrypted(with: SwiftyRSA.PublicKey(data: publicKeyX509), padding: .PKCS1)
+        let decrypted = try encrypted.decrypted(with: SwiftyRSA.PrivateKey(data: privateKeyX509), padding: .PKCS1)
         
         XCTAssertEqual(decrypted.data, data)
     }


### PR DESCRIPTION
Hello,

Our project currently faces a significant name collision issue. Specifically, the PublicKey class is implemented in both the MessageProtection framework and the SwiftyRSA framework. This is causing the following warning message to appear:

```csharp
objc[13599]: Class PublicKey is implemented in both /System/Library/PrivateFrameworks/MessageProtection.framework/MessageProtection (0x254bf2000) and /private/var/containers/Bundle/Application/9866BA82-B322-4442-BDD8-AD39140E4AEC/Band.app/Frameworks/SwiftyRSA.framework/SwiftyRSA (0x11354e1d0). One of the two will be used. Which one is undefined.
```

To resolve this issue, I propose renaming the PublicKey and PrivateKey classes within the SwiftyRSA framework to SwiftyRSAPublicKey and SwiftyRSAPrivateKey, respectively. This change will address the name collision and improve code readability and maintainability.

The changes are as follows:

PublicKey -> SwiftyRSA.PublicKey
PrivateKey -> SwiftyRSA.PrivateKey
I believe these changes will positively impact the project. I appreciate your review and feedback on this matter.

Thank you.