### PR TITLE
Fix Issue with SPM & Compiled xcframeworks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,14 +5,14 @@ let package = Package(
     name: "SwiftyRSA",
     products: [
         .library(
-            name: "SwiftyRSA",
-            targets: ["SwiftyRSA"]),
+            name: "SwiftyRSASDK",
+            targets: ["SwiftyRSASDK"]),
     ],
     dependencies: [
     ],
     targets: [
         .target(
-            name: "SwiftyRSA",
+            name: "SwiftyRSASDK",
             dependencies: [],
             path: "Source")
     ]


### PR DESCRIPTION
When the Package name is the same as a class/struct/enum etc the module interface fails validation when distributing an xcframework which has this dependency.  Whilst a breaking change (2.0.0 release required), this is the only option to allow for this.  Cocoapods & Carthage are unaffected.

@pc-scoop Please could we merge this and release 2.0.0?