### PR TITLE
Enable LibraryEvolution since the library is stable and avoid ABI bre…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,8 @@ let package = Package(
         .target(
             name: "SwiftyRSA",
             dependencies: [],
-            path: "Source")
+            path: "Source",
+            swiftSettings: [.unsafeFlags(["-enable-library-evolution"])]
+            )
     ]
 )

--- a/SwiftyRSA.podspec
+++ b/SwiftyRSA.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.exclude_files = "Source/SwiftyRSA+ObjC.swift"
   s.framework = "Security"
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
 
   s.swift_version = "5.0"
   s.ios.deployment_target = "10.0"


### PR DESCRIPTION
Enable LibraryEvolution since the library is stable and avoid ABI breaking issue when an xcframework uses SwiftyRSA

Example.
- MyLibrary is compiled to xcframework and it uses SwiftyRSA version x.1
- MyLibrary is used in application A, that uses SwiftyRSA version x.2
- SwiftyRSA version x.2 only reorders/inserts a new public function to a class, but without Library Evolution on, that can cause ABI breaking issue -> crash at runtime of application A, unexpected behaviour.

Benefits for prebuilt xcframework:

- ABI resilient
- Xcode/swift version compatibility